### PR TITLE
fix: use the latest stable docker image [DP-1303]

### DIFF
--- a/src/jobs/preview.yml
+++ b/src/jobs/preview.yml
@@ -31,7 +31,6 @@ steps:
         equal: [ true, << parameters.setup-remote-docker >> ]
       steps:
         - setup_remote_docker:
-            version: 19.03.13
             docker_layer_caching: true
   - preview:
       stack-name: << parameters.stack-name >>

--- a/src/jobs/update.yml
+++ b/src/jobs/update.yml
@@ -31,7 +31,6 @@ steps:
         equal: [ true, << parameters.setup-remote-docker >> ]
       steps:
         - setup_remote_docker:
-            version: 19.03.13
             docker_layer_caching: true
   - update:
       stack-name: << parameters.stack-name >>


### PR DESCRIPTION
Since CircleCI is conducting brownouts for several Remote Docker images and will be removing them from the platform on Sept 30, 2024, it’s necessary to use the recommended configuration by selecting the default image version, which uses the latest stable version (Docker 24)

Once an image is removed, the CircleCI jobs that use that image will fail with an error message - _This job was rejected because the image is unavailable._

Related incident: https://status.circleci.com/incidents/12xdkp5jmg4q 

For more information on Remote Docker image deprecation, please refer to this Discuss post: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176